### PR TITLE
Fix tests and open topics endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:studio": "prisma studio",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test": "node node_modules/jest/bin/jest.js",
+    "test:watch": "node node_modules/jest/bin/jest.js --watch",
+    "test:coverage": "node node_modules/jest/bin/jest.js --coverage"
   },
   "keywords": [
     "concursos",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,7 @@ const PORT = parseInt(process.env.PORT || '3001');
 app.use(helmet());
 
 // CORS configuration
-app.use(cors({
-  origin: ['http://localhost:5173', 'https://cardfix-frontend.vercel.app'],
-  credentials: true,
-}));
+app.use(cors());
 
 // Logging middleware
 app.use(morgan('combined'));

--- a/src/routes/topics.ts
+++ b/src/routes/topics.ts
@@ -11,17 +11,15 @@ import { authenticateToken } from '../middleware/auth';
 
 const router = Router();
 
-// All routes require authentication
-router.use(authenticateToken);
-
-// Topic CRUD
-router.post('/', createTopic);
+// Public routes
 router.get('/', getTopics);
 router.get('/:id', getTopic);
+
+// Routes requiring authentication
+router.use(authenticateToken);
+router.post('/', createTopic);
 router.put('/:id', updateTopic);
 router.delete('/:id', deleteTopic);
-
-// Topic statistics
 router.get('/:id/stats', getTopicStats);
 
 export default router;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "noImplicitAny": false,
-    "types": ["node"]
+    "types": ["node", "jest"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- adjust Jest scripts to execute via Node so tests run
- allow running Jest by adding jest types
- loosen CORS configuration to always send headers
- make topics listing public

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858049d5fb483299cf0bb54d15da5ec